### PR TITLE
notebook on temperature data from heincke and glider

### DIFF
--- a/notebooks/insitu_nrt_data.ipynb
+++ b/notebooks/insitu_nrt_data.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1c3dee5-6450-4c5e-bee6-1cf52fd5f20f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import sys\n",
+    "import os\n",
+    "import datetime\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import cmocean.cm as cmo\n",
+    "current_dir = os.getcwd()\n",
+    "src_path = Path(current_dir).parent / \"src\"\n",
+    "sys.path.insert(0, str(src_path))\n",
+    "from fetch_heincke_data import heincke_download_underway_data\n",
+    "from fetch_voto_data import glider_download_nrt_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99f804b8-38fd-454b-8412-7accdb2f14ab",
+   "metadata": {},
+   "source": [
+    "### Heincke data\n",
+    "\n",
+    "We get this from the Heincke data API (You can see the details in `sr/fetch_heincke_data.py`)\n",
+    "\n",
+    "By default, it fetches the most recent 24 hours. In this example, I ask for all the data from August. If you request too many rows the API will send an error! Pulling < 3 months is usually fine though. You can always request multiple batches, save them and combine them.\n",
+    "\n",
+    "**N.B.** If you get an error trying to re-download, just load your existing data with the cell below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "149c157f-4378-48f8-863c-cc4a423716f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_heincke = heincke_download_underway_data(start=datetime.datetime(2025,8,15), end=datetime.datetime(2025,8,31))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34d20c7a-1dc3-4692-8a21-66b8b03cd646",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_heincke_data():\n",
+    "    df = pd.read_csv(\"heincke_raw_data.csv\", sep='\\t', parse_dates=['datetime'])\n",
+    "\n",
+    "    df = df.rename({'vessel:heincke:trimble:longitude (mean) []': 'lon',\n",
+    "                    'vessel:heincke:trimble:latitude (mean) []': 'lat', \n",
+    "                    'vessel:heincke:tsg:salinity (mean) [0/00]': 'salinity [PSU]',\n",
+    "                    'vessel:heincke:tsg:sbe38:temperature (mean) [°C]': 'temperature [°C]',\n",
+    "                    }, axis=1)\n",
+    "    return df\n",
+    "df_heincke = read_heincke_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1248cb20-1e31-4b07-bbec-dbd5d769d63a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "c = ax.scatter(df_heincke.lon, df_heincke.lat, c=df_heincke['temperature [°C]'], cmap=cmo.thermal)\n",
+    "ax.set(xlabel='longitude', ylabel='latitide', title='Heincke TSG data')\n",
+    "plt.colorbar(c, label='Temperature [°C]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eef4382b-2110-4a64-b736-02118ac14b0c",
+   "metadata": {},
+   "source": [
+    "### Glider data\n",
+    "\n",
+    "Here we are requesting an old glider mission, we'll update this with the correct mission once we have deployed the glider. You can pass any dataset id from the [VOTO ERDDAP](https://erddap.observations.voiceoftheocean.org/erddap/info/index.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ca2f8e2-53da-4185-8a62-7265b39faaac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_glider = glider_download_nrt_data(dataset_id=\"nrt_SEA078_M29\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcf4f2c3-a370-4c51-93da-12907da09a11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_sub = df_glider[::10] # subset to speed up plotting\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "c = plt.scatter(df_sub.datetime, df_sub['depth (m)'], c=df_sub['temperature (Celsius)'], cmap=cmo.thermal)\n",
+    "ax.set(ylabel='depth', title='Glider data')\n",
+    "plt.colorbar(c, label='Temperature [°C]')\n",
+    "plt.xticks(rotation=45)\n",
+    "ax.invert_yaxis()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/fetch_heincke_data.py
+++ b/src/fetch_heincke_data.py
@@ -20,7 +20,7 @@ heincke_proc_csv = processed_location_data / "heincke.csv"
 def heincke_download_data():
     begin_date = (datetime.datetime.now() - datetime.timedelta(hours=24)).isoformat()[:19]
     end_date = (datetime.datetime.now() + datetime.timedelta(hours=2)).isoformat()[:19]
-    url = f"https://dashboard.awi.de/data-xxl/rest/data?beginDate={begin_date}&endDate={end_date}&aggregate=minute&aggregateFunctions=MEAN&sensors=vessel:heincke:trimble:longitude&sensors=vessel:heincke:trimble:latitude&sensors=vessel:heincke:saab:longitude&sensors=vessel:heincke:saab:latitude&sensors=vessel:heincke:phins:longitude&sensors=vessel:heincke:saab:latitude"
+    url = f"https://dashboard.awi.de/data-xxl/rest/data?beginDate={begin_date}&endDate={end_date}&aggregate=minute&aggregateFunctions=MEAN&sensors=vessel:heincke:trimble:longitude&sensors=vessel:heincke:trimble:latitude&sensors=vessel:heincke:saab:longitude&sensors=vessel:heincke:tsg:sbe38:temperature&sensors=vessel:heincke:tsg:salinity"
     req = requests.get(url)
     with open(heincke_raw_csv, "w") as fout:
         fout.write(req.text)
@@ -58,6 +58,23 @@ def combine_heincke_data():
     df_full = pd.concat([df_full, df])
     df_full = clean_locations(df_full)
     df_full.to_csv(heincke_proc_csv, index=False)
+
+def heincke_download_underway_data(start=datetime.datetime.now() - datetime.timedelta(hours=24), end=datetime.datetime.now() + datetime.timedelta(hours=2)):
+    raw_csv = "heincke_raw_data.csv"
+    begin_date = start.isoformat()[:19]
+    end_date = end.isoformat()[:19]
+    url = f"https://dashboard.awi.de/data-xxl/rest/data?beginDate={begin_date}&endDate={end_date}&aggregate=minute&aggregateFunctions=MEAN&sensors=vessel:heincke:trimble:longitude&sensors=vessel:heincke:trimble:latitude&sensors=vessel:heincke:tsg:sbe38:temperature&sensors=vessel:heincke:tsg:salinity"
+    req = requests.get(url)
+    with open(raw_csv, "w") as fout:
+        fout.write(req.text)
+    df = pd.read_csv(raw_csv, sep='\t', parse_dates=['datetime'])
+
+    df = df.rename({'vessel:heincke:trimble:longitude (mean) []': 'lon',
+                    'vessel:heincke:trimble:latitude (mean) []': 'lat', 
+                    'vessel:heincke:tsg:salinity (mean) [0/00]': 'salinity [PSU]',
+                    'vessel:heincke:tsg:sbe38:temperature (mean) [°C]': 'temperature [°C]',
+                    }, axis=1)
+    return df
 
 
 def main():

--- a/src/fetch_voto_data.py
+++ b/src/fetch_voto_data.py
@@ -6,15 +6,24 @@ root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 processed_location_data = Path(root_dir) / "data" / "processed_location_data"
 glider_csv = processed_location_data / "glider.csv"
-def download_glider_data():
+def download_glider_data(dataset_id = "nrt_SEA078_M29"):
     # Download sample glider data locations from VOTO ERDDAP
     df = pd.read_csv(
-        "https://erddap.observations.voiceoftheocean.org/erddap/tabledap/nrt_SEA078_M29.csvp?latitude%2Clongitude%2Ctime")
+        f"https://erddap.observations.voiceoftheocean.org/erddap/tabledap/{dataset_id}.csvp?latitude%2Clongitude%2Ctime")
     df = df[::100]
     df = df.rename({'longitude (degrees_east)': 'lon',
                     'latitude (degrees_north)': 'lat',
                     'time (UTC)': 'datetime'}, axis=1)
     df.to_csv(glider_csv, index=False)
+    
+def glider_download_nrt_data(dataset_id="nrt_SEA078_M29"):
+    df = pd.read_csv(
+        f"https://erddap.observations.voiceoftheocean.org/erddap/tabledap/{dataset_id}.csvp?latitude%2Clongitude%2Ctime%2Cdepth%2Ctemperature%2Csalinity")
+    df = df.rename({'longitude (degrees_east)': 'lon',
+                    'latitude (degrees_north)': 'lat',
+                    'time (UTC)': 'datetime'}, axis=1)
+    df['datetime'] = pd.to_datetime(df.datetime)
+    return df
 
 def main():
     download_glider_data()


### PR DESCRIPTION
This PR adds a notebook to download temperature data from Heincke and the VOTO glider. It makes some basic plots to show the data:

<img width="730" height="526" alt="image" src="https://github.com/user-attachments/assets/d6296e4e-5ce1-4494-ac9d-942541d06967" />
<img width="766" height="632" alt="image" src="https://github.com/user-attachments/assets/b418082c-a222-44ef-b2b8-8d007f6938ff" />

@GreteOcean once this is merged you can take this notebook as a starting point for making static plots of surface temperature from the various in-situ platforms 


This resolves #39