### PR TITLE
fix heincke tsg & add skagerak tsg

### DIFF
--- a/src/fetch_heincke_data.py
+++ b/src/fetch_heincke_data.py
@@ -17,14 +17,29 @@ heincke_raw_csv = rough_data / "heincke_raw.csv"
 processed_location_data = Path(root_dir) / "data" / "processed_location_data"
 heincke_proc_csv = processed_location_data / "heincke.csv"
 
-def heincke_download_data():
-    begin_date = (datetime.datetime.now() - datetime.timedelta(hours=24)).isoformat()[:19]
-    end_date = (datetime.datetime.now() + datetime.timedelta(hours=2)).isoformat()[:19]
-    url = f"https://ingest.o2a-data.de/rest/data?codes=vessel:heincke:trimble_5228k50585:latitude&codes=vessel:heincke:trimble_5228k50585:longitude&datetimeMin={begin_date}&datetimeMax={end_date}&aggregate=MINUTE&aggregateFunctions=MEAN"
-    print(url)
+def heincke_download_data(start=datetime.datetime.now() - datetime.timedelta(hours=24), end=datetime.datetime.now() + datetime.timedelta(hours=2), return_df=True):
+    begin_date = start.isoformat()[:19]
+    end_date = end.isoformat()[:19]
+    url = (f"https://ingest.o2a-data.de/rest/data?"
+           f"codes=vessel:heincke:trimble_5228k50585:latitude&"
+           f"codes=vessel:heincke:trimble_5228k50585:longitude&"
+           f"codes=vessel:heincke:tsg_heincke:sbe38_0474:watertemp&"
+           f"datetimeMin={begin_date}&"
+           f"datetimeMax={end_date}&"
+           f"aggregate=MINUTE&aggregateFunctions=MEAN")
     req = requests.get(url)
     with open(heincke_raw_csv, "w", encoding="utf-8") as fout:
         fout.write(req.text)
+    combine_heincke_data()
+    if return_df:
+        df = pd.read_csv(heincke_proc_csv, parse_dates=['datetime'], encoding="utf-8")
+        df = df.rename({'vessel:heincke:trimble:longitude (mean) []': 'lon',
+                        'vessel:heincke:trimble:latitude (mean) []': 'lat',
+                        'vessel:heincke:tsg:salinity (mean) [0/00]': 'salinity [PSU]',
+                        'vessel:heincke:tsg:sbe38:temperature (mean) [°C]': 'temperature [°C]',
+                        }, axis=1)
+        df_sub = df[(df.datetime >= start) & (df.datetime <= end)]
+        return df_sub
 
 
 
@@ -44,11 +59,10 @@ def clean_locations(df):
 def combine_heincke_data():
     df = pd.read_csv(heincke_raw_csv, parse_dates=['datetime'], encoding="utf-8", sep='\t')
     _log.info(f"reading in {len(df)} rows of downloaded data from R/V Heincke")
-    df = df[['datetime',
-             'vessel:heincke:trimble_5228k50585:longitude (mean) [°]',
-             'vessel:heincke:trimble_5228k50585:latitude (mean) [°]', ]]
     df = df.rename({'vessel:heincke:trimble_5228k50585:longitude (mean) [°]': 'lon',
-                    'vessel:heincke:trimble_5228k50585:latitude (mean) [°]': 'lat', }, axis=1)
+                    'vessel:heincke:trimble_5228k50585:latitude (mean) [°]': 'lat',
+                    'vessel:heincke:tsg_heincke:sbe38_0474:watertemp (mean) [°c]': 'temperature [°C]',
+                    }, axis=1)
     if heincke_proc_csv.exists():
         df_full = pd.read_csv(heincke_proc_csv, parse_dates=['datetime'], encoding="utf-8")
         df= df[df.datetime > df_full.datetime.max()]
@@ -62,24 +76,6 @@ def combine_heincke_data():
     df_full = clean_locations(df_full)
     df_full.to_csv(heincke_proc_csv, index=False, encoding="utf-8")
 
-def heincke_download_underway_data(start=datetime.datetime.now() - datetime.timedelta(hours=24), end=datetime.datetime.now() + datetime.timedelta(hours=2)):
-    raw_csv = heincke_raw_csv
-    start_new, end_new = heincke_download_check_times(start, end)
-    begin_date = start_new.isoformat()[:19]
-    end_date = end_new.isoformat()[:19]
-    url = f"https://dashboard.awi.de/data-xxl/rest/data?beginDate={begin_date}&endDate={end_date}&aggregate=minute&aggregateFunctions=MEAN&sensors=vessel:heincke:trimble:longitude&sensors=vessel:heincke:trimble:latitude&sensors=vessel:heincke:tsg:sbe38:temperature&sensors=vessel:heincke:tsg:salinity"
-    req = requests.get(url)
-    with open(raw_csv, "w", encoding="utf-8") as fout:
-        fout.write(req.text)  
-    combine_heincke_data()   
-    df = pd.read_csv(heincke_proc_csv, parse_dates=['datetime'], encoding="utf-8")
-    df = df.rename({'vessel:heincke:trimble:longitude (mean) []': 'lon',
-                    'vessel:heincke:trimble:latitude (mean) []': 'lat', 
-                    'vessel:heincke:tsg:salinity (mean) [0/00]': 'salinity [PSU]',
-                    'vessel:heincke:tsg:sbe38:temperature (mean) [°C]': 'temperature [°C]',
-                    }, axis=1)
-    df_sub = df[(df.datetime >= start) & (df.datetime <= end)]
-    return df_sub
 
 def heincke_download_check_times(start, end):
     try: 
@@ -92,10 +88,10 @@ def heincke_download_check_times(start, end):
         end_new =  df.datetime.min()
     return start_new, end_new
 
+heincke_download_underway_data = heincke_download_data
 
 def main():
-    heincke_download_data()
-    combine_heincke_data()
+    heincke_download_data(return_df=False)
 
 if __name__ == '__main__':
     logging.basicConfig(

--- a/src/fetch_heincke_data.py
+++ b/src/fetch_heincke_data.py
@@ -17,7 +17,7 @@ heincke_raw_csv = rough_data / "heincke_raw.csv"
 processed_location_data = Path(root_dir) / "data" / "processed_location_data"
 heincke_proc_csv = processed_location_data / "heincke.csv"
 
-def heincke_download_data(start=datetime.datetime.now() - datetime.timedelta(hours=24), end=datetime.datetime.now() + datetime.timedelta(hours=2), return_df=True):
+def heincke_download_data(start=datetime.datetime.now() - datetime.timedelta(hours=24), end=datetime.datetime.now() + datetime.timedelta(hours=2), return_df=True, remove_cached=True):
     begin_date = start.isoformat()[:19]
     end_date = end.isoformat()[:19]
     url = (f"https://ingest.o2a-data.de/rest/data?"
@@ -30,6 +30,9 @@ def heincke_download_data(start=datetime.datetime.now() - datetime.timedelta(hou
     req = requests.get(url)
     with open(heincke_raw_csv, "w", encoding="utf-8") as fout:
         fout.write(req.text)
+    if remove_cached:
+        if heincke_proc_csv.exists():
+            heincke_proc_csv.unlink()
     combine_heincke_data()
     if return_df:
         df = pd.read_csv(heincke_proc_csv, parse_dates=['datetime'], encoding="utf-8")
@@ -88,10 +91,8 @@ def heincke_download_check_times(start, end):
         end_new =  df.datetime.min()
     return start_new, end_new
 
-heincke_download_underway_data = heincke_download_data
-
 def main():
-    heincke_download_data(return_df=False)
+    heincke_download_data(remove_cached=False)
 
 if __name__ == '__main__':
     logging.basicConfig(

--- a/src/fetch_skagerak_data.py
+++ b/src/fetch_skagerak_data.py
@@ -17,7 +17,7 @@ skagerak_raw_csv = rough_data / "skagerak_raw.csv"
 processed_location_data = Path(root_dir) / "data" / "processed_location_data"
 skagerak_proc_csv = processed_location_data / "skagerak.csv"
 
-def skagerak_download_data(records=100, return_df=True):
+def skagerak_download_data(records=100, return_df=True, remove_cached=True):
     url = f"https://postgrest-skagerak.apps.k8s.gu.se/sk_position?limit={records}&order=ts.desc"
     req = requests.get(url)
     json_data = req.json()
@@ -30,6 +30,9 @@ def skagerak_download_data(records=100, return_df=True):
     df = df.tz_localize('UTC')
     df = df.drop('datetime', axis=1)
     df.to_csv(skagerak_raw_csv)
+    if remove_cached:
+        if skagerak_proc_csv.exists():
+            skagerak_proc_csv.unlink()
     combine_skagerak_data()
     if return_df:
         df_full = pd.read_csv(skagerak_proc_csv, parse_dates=['datetime'], encoding="utf-8")
@@ -54,8 +57,7 @@ def combine_skagerak_data():
 
 def skagerak_download_tsg_data(records=10000):
     url = f"https://postgrest-skagerak.apps.k8s.gu.se/sk_ferrybox?limit={records}&order=ts.desc"
-    if not skagerak_proc_csv.exists():
-        skagerak_download_data(records=records)
+    skagerak_download_data(records=records)
     req = requests.get(url)
     json_data = req.json()
     df = pd.DataFrame(json_data)
@@ -72,7 +74,7 @@ def skagerak_download_tsg_data(records=10000):
     
     
 def main():
-    skagerak_download_data(return_df=False)
+    skagerak_download_data(remove_cached=False)
 
 if __name__ == '__main__':
     logging.basicConfig(

--- a/src/fetch_skagerak_data.py
+++ b/src/fetch_skagerak_data.py
@@ -1,5 +1,6 @@
 import requests
 import pandas as pd
+import numpy as np
 import sys
 import geopandas as gpd
 import os
@@ -16,8 +17,8 @@ skagerak_raw_csv = rough_data / "skagerak_raw.csv"
 processed_location_data = Path(root_dir) / "data" / "processed_location_data"
 skagerak_proc_csv = processed_location_data / "skagerak.csv"
 
-def skagerak_download_data():
-    url = f"https://postgrest-skagerak.apps.k8s.gu.se/sk_position?limit=100&order=ts.desc"
+def skagerak_download_data(records=100, return_df=True):
+    url = f"https://postgrest-skagerak.apps.k8s.gu.se/sk_position?limit={records}&order=ts.desc"
     req = requests.get(url)
     json_data = req.json()
     gdf = gpd.GeoDataFrame(json_data)
@@ -29,6 +30,10 @@ def skagerak_download_data():
     df = df.tz_localize('UTC')
     df = df.drop('datetime', axis=1)
     df.to_csv(skagerak_raw_csv)
+    combine_skagerak_data()
+    if return_df:
+        df_full = pd.read_csv(skagerak_proc_csv, parse_dates=['datetime'], encoding="utf-8")
+        return df_full
 
 
 def combine_skagerak_data():
@@ -47,10 +52,27 @@ def combine_skagerak_data():
     df_full = df_full.sort_values("datetime")
     df_full.to_csv(skagerak_proc_csv, encoding="utf-8", index=False)
 
-
+def skagerak_download_tsg_data(records=10000):
+    url = f"https://postgrest-skagerak.apps.k8s.gu.se/sk_ferrybox?limit={records}&order=ts.desc"
+    if not skagerak_proc_csv.exists():
+        skagerak_download_data(records=records)
+    req = requests.get(url)
+    json_data = req.json()
+    df = pd.DataFrame(json_data)
+    df = df.rename({'ts': 'datetime'}, axis=1)
+    df = df.sort_values("datetime")
+    df.index = (pd.to_datetime(df.datetime))
+    df = df.tz_localize('UTC')
+    df = df.drop('datetime', axis=1)
+    df_loc = pd.read_csv(skagerak_proc_csv, parse_dates=['datetime'])
+    df_combi = pd.merge_asof(df, df_loc, left_on='datetime', right_on='datetime')
+    df_combi = df_combi[~np.isnan(df_combi.lon)]
+    return df_combi
+    
+    
+    
 def main():
-    skagerak_download_data()
-    combine_skagerak_data()
+    skagerak_download_data(return_df=False)
 
 if __name__ == '__main__':
     logging.basicConfig(


### PR DESCRIPTION
This fixes the TSG fetch for Heinke after the API migration and adds TSG fetch for skagerak.

This changes and simplifies how we fetch data from these two sources. You should remove cached data downlaoded using the old scheme. Namely, delete the files `heincke.csv` and `skagerak.csv` from **data/processed_location_data** before running the commands below 

to download tsg data

```python
df_heincke = heincke_download_data(start=datetime.datetime(2025,8,15), end=datetime.datetime(2025,8,31))# pass datetime objects. Defaults to last 24 houts
df = skagerak_download_tsg_data(records=10000) # one record per minute, increase to get data from further back in time
```

