### PR TITLE
add tooltips of vessel names

### DIFF
--- a/skamixmap.html
+++ b/skamixmap.html
@@ -20,6 +20,8 @@
 	<script src="/static/skamix/Leaflet.Graticule.js" type="text/javascript"></script>
 	<script src='https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/Leaflet.fullscreen.min.js'></script>
 	<link href='https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/leaflet.fullscreen.css' rel='stylesheet' />
+    <link rel="stylesheet" href="/static/skamix/skamix.css?version=2"/>
+
 
 {% endblock %}
 
@@ -110,6 +112,9 @@ var chl_l4 = L.tileLayer(template, {
 
 // Function adds popup content to markers
 function popupText(feature, layer) {
+  	if (feature.properties.tooltipContent) {
+     	layer.bindTooltip(feature.properties.tooltipContent, {permanent: true, interactive: true, className: 'labelstyle', opacity:0.8});
+   	}
 	layer.bindPopup(feature.properties.popupContent);}
 
 // Add demo data incorporating style and popup info from the geojson

--- a/src/make_demo_geojson.py
+++ b/src/make_demo_geojson.py
@@ -70,7 +70,8 @@ def locations_to_geojson_point(df, popup):
     point_dict = {
         "type": "Feature",
         "properties": {
-            "popupContent": popup
+            "popupContent": popup,
+            "tooltipContent": popup.split('<br>')[0]
         },
         "geometry": {"type": "Point", "coordinates": [coords[-1][0], coords[-1][1]]
                      }


### PR DESCRIPTION
Adds tooltips of the platforms to distinguish them more easily

<img width="1425" height="890" alt="image" src="https://github.com/user-attachments/assets/d90446a0-0b32-4e24-bc18-656bb0d4a9e6" />


Useful or irritating @GreteOcean ?